### PR TITLE
Changes to make RestController work even if outside the base package

### DIFF
--- a/src/main/java/com/courseAPISpringBoot/CourseApiApp.java
+++ b/src/main/java/com/courseAPISpringBoot/CourseApiApp.java
@@ -2,8 +2,10 @@ package com.courseAPISpringBoot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(basePackages = { "com.courseAPISpringBoot","com.courseAPI.topic"} )
 public class CourseApiApp {
 
     public static void main( String[] args){


### PR DESCRIPTION
Changes to CourseApiApp.java 
`@ComponentScan(basePackages = { "com.courseAPISpringBoot","com.courseAPI.topic"} )`
Specifies list of all packages to scan for annotation
Default behavior - Current package and sub-package